### PR TITLE
Move Lap Counter

### DIFF
--- a/apps/desktop/src/renderer/app-actions.ts
+++ b/apps/desktop/src/renderer/app-actions.ts
@@ -1,0 +1,11 @@
+import { AppState } from "./app-state";
+
+export const appActions = {
+    liveData: {
+        liveDataReceived: () => ({ anyDataReceived: true }),
+        currentLapChanged: (currentLap: number) => ({ currentLap })
+    },
+    getState: () => (state: AppState) => state
+};
+
+export type AppActions = typeof appActions;

--- a/apps/desktop/src/renderer/app-container/app-container.tsx
+++ b/apps/desktop/src/renderer/app-container/app-container.tsx
@@ -1,0 +1,34 @@
+import { AppState } from '../app-state';
+import { LapCounter } from '../lap-counter/lap-counter';
+import { h } from 'hyperapp';
+
+export const AppContainer = (state: AppState) => {
+    return (
+        <div id="container">
+            <div class="log">
+                <LapCounter />
+                <h3 class="time">Time:</h3>
+                <div>
+                    <h3>Stats</h3>
+                    <ul class="stats">
+                        <li class="fps"></li>
+                        <li class="total-points"></li>
+                        <li class="displayed-points"></li>
+                        <li class="speed-points"></li>
+                        <li class="throttle-points"></li>
+                        <li class="brake-points"></li>
+                        <li class="gear-points"></li>
+                        <li class="steering-points"></li>
+                        <li class="compressed-points"></li>
+                    </ul>
+                </div>
+            </div>
+            <canvas width="1200" height="200" id="speed-plot"></canvas>
+            <canvas width="1200" height="200" id="throttle-plot"></canvas>
+            <canvas width="1200" height="200" id="brake-plot"></canvas>
+            <canvas width="1200" height="200" id="gear-plot"></canvas>
+            <canvas width="1200" height="200" id="compressed-plot"></canvas>
+            <canvas width="1200" height="200" id="steering-plot"></canvas>
+        </div>
+    );
+};

--- a/apps/desktop/src/renderer/app-state.ts
+++ b/apps/desktop/src/renderer/app-state.ts
@@ -1,0 +1,12 @@
+export interface AppState {
+    liveData: {
+        anyDataReceived: boolean;
+        currentLap?: number;
+    }
+};
+
+export const appInitialState = {
+    liveData: {
+        anyDataReceived: false
+    }
+};

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,50 +1,17 @@
 import Chart, { ChartConfiguration } from 'chart.js';
 import { round } from 'lodash';
-import { h, app } from 'hyperapp';
 import * as core from 'f1-laps-js-bridge';
-
-core.initialise({ updateInterval: 30, storagePath: '../../_data-storage' });
-
-const state = {};
-const actions = {};
+import { startApp } from './start-app';
+import { appInitialState } from './app-state';
+import { appActions } from './app-actions';
+import { AppContainer } from './app-container/app-container';
 
 const MAX_CHART_X = 120;
 
-const view = () => {
-    return (
-        <div id="container" onCreate={setTimeout(setupApp, 1000)}>
-            <div class="log">
-                <h3 class="lap-counter">Lap:</h3>
-                <h3 class="time">Time:</h3>
-                <div>
-                    <h3>Stats</h3>
-                    <ul class="stats">
-                        <li class="fps"></li>
-                        <li class="total-points"></li>
-                        <li class="displayed-points"></li>
-                        <li class="speed-points"></li>
-                        <li class="throttle-points"></li>
-                        <li class="brake-points"></li>
-                        <li class="gear-points"></li>
-                        <li class="steering-points"></li>
-                        <li class="compressed-points"></li>
-                    </ul>
-                </div>
-            </div>
-            <canvas width="1200" height="200" id="speed-plot"></canvas>
-            <canvas width="1200" height="200" id="throttle-plot"></canvas>
-            <canvas width="1200" height="200" id="brake-plot"></canvas>
-            <canvas width="1200" height="200" id="gear-plot"></canvas>
-            <canvas width="1200" height="200" id="compressed-plot"></canvas>
-            <canvas width="1200" height="200" id="steering-plot"></canvas>
-        </div>
-    );
-};
-
-app(state, actions, view, document.querySelector('#app'));
+startApp(core, appInitialState, appActions, AppContainer, document.getElementById('app'));
+setTimeout(setupApp, 1000);
 
 function setupApp() {
-    let lapCounter = document.querySelector('.lap-counter');
     let timeElem = document.querySelector('.time');
     let fpsElem = document.querySelector('.fps');
     let displayedPointsElem = document.querySelector('.displayed-points');
@@ -167,8 +134,6 @@ function setupApp() {
         time.push(data.currentLapTime);
 
         totalDataPoints++;
-
-        lapCounter.innerHTML = 'Lap: ' + data.currentLap;
     });
 
     let speedPlot: Plot;

--- a/apps/desktop/src/renderer/lap-counter/lap-counter.tsx
+++ b/apps/desktop/src/renderer/lap-counter/lap-counter.tsx
@@ -1,0 +1,8 @@
+import { h } from 'hyperapp';
+import { AppState } from '../app-state';
+
+export const LapCounter = () => ({ liveData: { currentLap }}: AppState) => (
+    <h3 class="lap-counter">
+        Lap: { currentLap }
+    </h3>
+);

--- a/apps/desktop/src/renderer/start-app.ts
+++ b/apps/desktop/src/renderer/start-app.ts
@@ -1,0 +1,21 @@
+import * as JSBridgeCore from 'f1-laps-js-bridge';
+import { app, View } from 'hyperapp';
+import { AppActions } from './app-actions';
+import { AppState } from './app-state';
+
+export function startApp(
+    core: typeof JSBridgeCore,
+    state: AppState,
+    actions: AppActions,
+    view: View<AppState, AppActions>,
+    container: Element | null
+) {
+    core.initialise({ updateInterval: 30, storagePath: '../../_data-storage' });
+    const boundActions = app(state, actions, view, container);
+
+    core.liveData.register(data => {
+        boundActions.liveData.liveDataReceived(),
+        boundActions.liveData.currentLapChanged(data.currentLap)
+    });
+    (window as any).gs = boundActions.getState;
+}


### PR DESCRIPTION
- Move state, view and actions into their own files
- Make `startApp()` function which will be the injection point, taking all the app dependencies and starting the app logic
- First step in actually using hyperapp by moving lap counter to it's own component which gets its state from hyperapp