### PR TITLE
Add naive plot component

### DIFF
--- a/apps/desktop/src/renderer/app-actions.ts
+++ b/apps/desktop/src/renderer/app-actions.ts
@@ -1,9 +1,42 @@
-import { AppState } from "./app-state";
+import { AppState, LiveData, ActivePlots } from "./app-state";
+import { LapTick } from "f1-laps-js-bridge";
+import { Point } from "./math/linear-algebra";
+
+const TIME_RANGE = 100;
+
+function filterInvisible(arr: Array<Point>, currentTime: number) {
+    const firstVisible = arr.findIndex(a => a.x > currentTime - TIME_RANGE);
+
+    return arr.slice(firstVisible);
+}
+
+function updateLapPlot(arr: Array<Point>, newPoint: Point) {
+    return filterInvisible(arr, newPoint.x).concat([newPoint]);
+}
 
 export const appActions = {
     liveData: {
         liveDataReceived: () => ({ anyDataReceived: true }),
-        currentLapChanged: (currentLap: number) => ({ currentLap })
+        currentLapChanged: (currentLap: number) => ({ currentLap }),
+        dataPointReceived: (lapTick: LapTick) => ({ speed }: LiveData) => {
+            return {
+                speed: updateLapPlot(speed, {
+                    x: lapTick.currentLapTime,
+                    y: lapTick.currentSpeed
+                })
+            };
+        }
+    },
+    activePlots: {
+        plotActive: ({
+            key,
+            activePlot
+        }: { key: string; activePlot: Chart }) => (
+            activePlots: ActivePlots
+        ) => ({
+            ...activePlots,
+            [key]: activePlot
+        })
     },
     getState: () => (state: AppState) => state
 };

--- a/apps/desktop/src/renderer/app-container/app-container.tsx
+++ b/apps/desktop/src/renderer/app-container/app-container.tsx
@@ -1,6 +1,7 @@
 import { AppState } from '../app-state';
 import { LapCounter } from '../lap-counter/lap-counter';
 import { h } from 'hyperapp';
+import { TelemetryPlot } from '../chart/telemetry-plot';
 
 export const AppContainer = (state: AppState) => {
     return (
@@ -23,6 +24,7 @@ export const AppContainer = (state: AppState) => {
                     </ul>
                 </div>
             </div>
+            <TelemetryPlot key="speed" suggestedYRange={[0, 420]} data={state.liveData.speed} />
             <canvas width="1200" height="200" id="speed-plot"></canvas>
             <canvas width="1200" height="200" id="throttle-plot"></canvas>
             <canvas width="1200" height="200" id="brake-plot"></canvas>

--- a/apps/desktop/src/renderer/app-state.ts
+++ b/apps/desktop/src/renderer/app-state.ts
@@ -1,12 +1,22 @@
+import { Point } from "./math/linear-algebra";
+
+export interface LiveData {
+    anyDataReceived: boolean;
+    currentLap?: number;
+    speed: Array<Point>;
+}
+
+export type ActivePlots = { [key: string]: Chart }
+
 export interface AppState {
-    liveData: {
-        anyDataReceived: boolean;
-        currentLap?: number;
-    }
+    liveData: LiveData;
+    activePlots: ActivePlots;
 };
 
-export const appInitialState = {
+export const appInitialState: AppState = {
     liveData: {
-        anyDataReceived: false
-    }
+        anyDataReceived: false,
+        speed: []
+    },
+    activePlots: {}
 };

--- a/apps/desktop/src/renderer/chart/telemetry-plot.tsx
+++ b/apps/desktop/src/renderer/chart/telemetry-plot.tsx
@@ -1,0 +1,135 @@
+import { h } from 'hyperapp';
+import { Point } from '../math/linear-algebra';
+import { round } from 'lodash';
+import Chart, { ChartConfiguration } from 'chart.js';
+import { AppState } from '../app-state';
+import { AppActions } from '../app-actions';
+
+const MAX_CHART_X = 120;
+
+function filterXBoundingTicks(tickVal: number, index: number, allTicks: Array<Point>) {
+    if (index === 0) {
+        return round(tickVal, 1);
+    }
+
+    if (index === allTicks.length - 1) {
+        return '';
+    }
+
+    return tickVal;
+}
+
+function filterYBoundingTicks(tickVal: number, index: number, allTicks: Array<Point>) {
+    if (index === 0) {
+        return null;
+    }
+
+    if (index === allTicks.length - 1 && tickVal < 0) {
+        return '';
+    }
+
+    return tickVal;
+}
+
+const createChart = (
+    {
+        suggestedYRange,
+        key
+    }: TelemetryPlotAttributes,
+    actions: AppActions
+) => (
+    canvas: HTMLCanvasElement
+) => {
+        const newChart = new Chart(
+            canvas.getContext('2d'),
+            {
+                type: 'scatter',
+                data: {
+                    datasets: [
+                        {
+                            borderColor: 'rgba(66, 134, 244, 1)',
+                            backgroundColor: 'rgba(66, 134, 244, 1)',
+                            label: name,
+                            fill: false,
+                            data: []
+                        }
+                    ]
+                },
+                options: {
+                    showLines: true,
+                    responsive: false,
+                    animation: {
+                        duration: 0
+                    },
+                    events: ['click'],
+                    elements: {
+                        point: {
+                            radius: 0,
+                            hitRadius: 0
+                        },
+                        line: {
+                            tension: 0
+                        }
+                    },
+                    scales: {
+                        xAxes: [
+                            {
+                                ticks: {
+                                    maxRotation: 0,
+                                    min: 0,
+                                    max: MAX_CHART_X,
+                                    callback: filterXBoundingTicks
+                                },
+                            }
+                        ],
+                        yAxes: [
+                            {
+                                ticks: {
+                                    min: suggestedYRange[0],
+                                    max: suggestedYRange[1],
+                                    callback: filterYBoundingTicks
+                                }
+                            }
+                        ]
+                    }
+                }
+            } as ChartConfiguration);
+
+        actions.activePlots.plotActive({
+            key,
+            activePlot: newChart
+        });
+    }
+
+const onTelemetryPlotUpdate = (
+    currentAttributes: TelemetryPlotAttributes,
+    activePlots: { [key: string]: Chart }
+) => (
+    element: HTMLCanvasElement, oldAttributes: TelemetryPlotAttributes
+) => {
+        if (oldAttributes.data !== currentAttributes.data) {
+            const activePlot = activePlots[currentAttributes.key];
+            activePlot.data.datasets[0].data = currentAttributes.data;
+            activePlot.update();
+        }
+    }
+
+export const TelemetryPlot = (
+    attributes: TelemetryPlotAttributes
+) => (
+    { activePlots }: AppState,
+    actions: AppActions
+) => (
+    <canvas
+        width="1200"
+        height="200"
+        oncreate={createChart(attributes, actions)}
+        onupdate={onTelemetryPlotUpdate(attributes, activePlots)}
+    />
+);
+
+export interface TelemetryPlotAttributes {
+    suggestedYRange: [number, number];
+    data: Array<Point>;
+    key: string;
+}

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -5,6 +5,7 @@ import { startApp } from './start-app';
 import { appInitialState } from './app-state';
 import { appActions } from './app-actions';
 import { AppContainer } from './app-container/app-container';
+import { Point } from './math/linear-algebra';
 
 const MAX_CHART_X = 120;
 
@@ -321,11 +322,6 @@ function setupApp() {
     // }
 
     core.replayAllLaps();
-}
-
-interface Point {
-    x: number;
-    y: number;
 }
 
 type Plot = Chart & ChartConfiguration;

--- a/apps/desktop/src/renderer/math/linear-algebra.ts
+++ b/apps/desktop/src/renderer/math/linear-algebra.ts
@@ -1,0 +1,4 @@
+export interface Point {
+    x: number;
+    y: number;
+}

--- a/apps/desktop/src/renderer/start-app.ts
+++ b/apps/desktop/src/renderer/start-app.ts
@@ -14,8 +14,9 @@ export function startApp(
     const boundActions = app(state, actions, view, container);
 
     core.liveData.register(data => {
-        boundActions.liveData.liveDataReceived(),
-        boundActions.liveData.currentLapChanged(data.currentLap)
+        boundActions.liveData.liveDataReceived();
+        boundActions.liveData.currentLapChanged(data.currentLap);
+        boundActions.liveData.dataPointReceived(data);
     });
     (window as any).gs = boundActions.getState;
 }


### PR DESCRIPTION
Preparation for moving the charts to their own component
Add a basic plot component that will render a canvas and do the relevant chart.js calls.
It naively updates every time its `data` attribute changes at the moment. It is not hooked in to the previous `requestAnimationFrame` optimizations to update the line & the scale separately and less frequently.
This adds in speed data only to the hyperapp `state`
