### PR TITLE
Rename LiveData to LapTick

### DIFF
--- a/modules/js-bridge/src/index.ts
+++ b/modules/js-bridge/src/index.ts
@@ -2,15 +2,15 @@ const core = require('../native');
 const stayAwake = require('stay-awake');
 
 import { createSubject, createObservable } from '@bunch-of-friends/observable';
-import { NewSession, LiveData, LapFinished, SectorFinished, LapMetadata } from './types';
+import { NewSession, LapTick, LapFinished, SectorFinished, LapMetadata } from './types';
 
 export * from './types';
 export * from '@bunch-of-friends/observable';
 
 let newSessionSubject = createSubject<NewSession>();
 let newSessionObservable = createObservable<NewSession>(newSessionSubject);
-let liveDataSubject = createSubject<LiveData>();
-let liveDataObservable = createObservable<LiveData>(liveDataSubject);
+let liveDataSubject = createSubject<LapTick>();
+let liveDataObservable = createObservable<LapTick>(liveDataSubject);
 let lapFinishedSubject = createSubject<LapFinished>();
 let lapFinishedObservable = createObservable<LapFinished>(lapFinishedSubject);
 let sectorFinishedSubject = createSubject<SectorFinished>();
@@ -79,7 +79,7 @@ export function replayAllLaps() {
     core.replayAllLaps();
 }
 
-export function getLapData(identifier: string): Array<LiveData> {
+export function getLapData(identifier: string): Array<LapTick> {
     checkInitialised();
 
     return core.getLapData(identifier);

--- a/modules/js-bridge/src/types.ts
+++ b/modules/js-bridge/src/types.ts
@@ -160,7 +160,7 @@ export interface CarTick {
     penalties: number;
 }
 
-export interface LiveData {
+export interface LapTick {
     currentLap: number;
     currentLapTime: number;
     currentSector: Sector;


### PR DESCRIPTION
I realised I was working against an older `js-bridge` where the `LiveData` is named `LapTick` so there are compile errors. This PR changes it back to `LapTick` in the bridge but happy to discuss as its better to be consistent with Rust too...

I prefer `LapTick` over `LiveData` at the moment as
- regardless of whether the data is actually streamed live, each lap data update will have the structure defined in that interface.
- it is not obvious whether `LiveData` means all the live data or one data point, whereas `Tick` is very clear

Or maybe it needs to be named something else entirely....